### PR TITLE
Fix bug with capitalised page and size query string parameters.

### DIFF
--- a/src/Restful.Wiretypes/Page.cs
+++ b/src/Restful.Wiretypes/Page.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -90,7 +91,10 @@ namespace Restful.Wiretypes
 
         static string StripPagingInfoFrom(string pathAndQuery)
         {
-            var parts = pathAndQuery.Split(new[] {'?', '&'}).Where(x => !x.StartsWith("page=") && !x.StartsWith("size="));
+            var parts = pathAndQuery.Split(new[] { '?', '&' })
+                .Where(x => !x.StartsWith("page=", true, CultureInfo.InvariantCulture)
+                         && !x.StartsWith("size=", true, CultureInfo.InvariantCulture));
+
             var s = new StringBuilder();
             var sep = '?';
             foreach (var part in parts)


### PR DESCRIPTION
Supports both lowercase and capitalised _page_ and _size_ parameters in the passed up query string.
